### PR TITLE
Make plugin compatible with multisite installs

### DIFF
--- a/admin/class-make-paths-relative-admin.php
+++ b/admin/class-make-paths-relative-admin.php
@@ -109,9 +109,14 @@ final class Make_Paths_Relative_Admin {
         'styles_src'           =>  $_POST['styles_src'],
         'image_paths'          =>  $_POST['image_paths']
       );
-      update_site_option( 'make_paths_relative', serialize( $save_settings ) );
+      if( is_multisite() ) {
+	  	update_site_option( 'make_paths_relative', serialize( $save_settings ) );
+	  } else {
+		update_option( 'make_paths_relative', serialize( $save_settings ) );
+	  }
     }
-    $settings         = unserialize( get_site_option( 'make_paths_relative' ) );
+	$opt = is_multisite() ? get_site_option( 'make_paths_relative' ) : get_option( 'make_paths_relative' );
+    $settings         = unserialize( $opt );
     $site_url         = '';
     $enabled_post     = '';
     $enabled_page     = '';
@@ -124,7 +129,7 @@ final class Make_Paths_Relative_Admin {
     if ( isset( $settings ) ) {
       if ( isset( $settings['site_url'] )
         && ! empty( $settings['site_url'] ) ) {
-        $site_url = str_replace( '/wp', '/', $settings['site_url'] );
+        $site_url = $settings['site_url'];
       }
       if ( esc_attr( $settings['post_permalinks'] ) == 'on' ) {
         $enabled_post = 'checked';
@@ -174,7 +179,7 @@ final class Make_Paths_Relative_Admin {
               </th>
               <td>
                 <input type="text" name="site_url" class="regular-text" value="<?php echo $site_url; ?>" />
-                <small><?php printf( __( 'Default : %s', 'make-paths-relative' ), $site_url ? $site_url : str_replace( '/wp', '/', get_site_url() ) ); ?></small>
+                <small><?php printf( __( 'Default : %s', 'make-paths-relative' ), $site_url ? $site_url : get_site_url() ); ?></small>
                 <div><?php printf( __( 'Leave the field empty to use the <strong>%s</strong> address', 'make-paths-relative' ), $print_site_url ); ?></div>
               </td>
             </tr>
@@ -284,14 +289,19 @@ final class Make_Paths_Relative_Admin {
         }
         $exclude_post_types['post_types'][$key] = $value;
       }
-      update_site_option( 'make_paths_relative_exclude',
-        serialize( $exclude_post_types )
-      );
+      if ( is_multisite() ) {
+		  update_site_option( 'make_paths_relative_exclude', serialize( $exclude_post_types ) );
+	  } else {
+		  update_option( 'make_paths_relative_exclude', serialize( $exclude_post_types ) );
+	  }
     }
     $post_types     = get_post_types( '', 'objects' );
-    $excluded_types = unserialize(
-      get_site_option( 'make_paths_relative_exclude' )
-    );
+
+	if ( is_multisite() ) {
+	  $excluded_types = unserialize( get_site_option( 'make_paths_relative_exclude' ) );
+	} else {
+	  $excluded_types = unserialize( get_option( 'make_paths_relative_exclude' ) );
+	}
     ?>
     <div class="wrap">
       <h1><?php _e( 'Exclude Posts', 'make-paths-relative' ); ?></h1>

--- a/admin/class-make-paths-relative-admin.php
+++ b/admin/class-make-paths-relative-admin.php
@@ -36,20 +36,22 @@ final class Make_Paths_Relative_Admin {
    * @return void
    */
   public function admin_menu() {
+  	$envcap = is_multisite() ? 'manage_network' : 'administrator';
+
     add_menu_page( 'Make Paths Relative Settings', 'Make Paths Relative',
-      'manage_network', 'make-paths-relative-settings',
+      $envcap, 'make-paths-relative-settings',
       array( $this, 'admin_settings_page' )
     );
     add_submenu_page( 'make-paths-relative-settings',
-      'Make Paths Relative Settings', 'Settings', 'manage_network',
+      'Make Paths Relative Settings', 'Settings', $envcap,
       'make-paths-relative-settings', array( $this, 'admin_settings_page' )
     );
     add_submenu_page( 'make-paths-relative-settings', 'Exclude Posts',
-      'Exclude Posts', 'manage_network', 'make-paths-relative-exclude-posts',
+      'Exclude Posts', $envcap, 'make-paths-relative-exclude-posts',
       array( $this, 'exclude_posts_page' )
     );
     add_submenu_page( 'make-paths-relative-settings', 'About',
-      'About', 'manage_network', 'make-paths-relative-about-plugins',
+      'About', $envcap, 'make-paths-relative-about-plugins',
       array( $this, 'about_plugin' )
     );
 
@@ -70,7 +72,9 @@ final class Make_Paths_Relative_Admin {
    * @return void
    */
   public function admin_settings_page() {
-    if ( ! current_user_can( 'manage_network' ) )  {
+  	$envcap = is_multisite() ? 'manage_network' : 'administrator';
+
+  	if ( ! current_user_can( $envcap ) )  {
       wp_die( __( 'You do not have sufficient permissions to access this page.' ) );
     }
     if ( isset( $_POST['submit'] ) ) {
@@ -276,7 +280,9 @@ final class Make_Paths_Relative_Admin {
    * @return void
    */
   public function exclude_posts_page() {
-    if ( ! current_user_can( 'manage_network' ) )  {
+  	$envcap = is_multisite() ? 'manage_network' : 'administrator';
+
+  	if ( ! current_user_can( $envcap ) )  {
       wp_die(
         __( 'You do not have sufficient permissions to access this page.' )
       );
@@ -295,7 +301,7 @@ final class Make_Paths_Relative_Admin {
 		  update_option( 'make_paths_relative_exclude', serialize( $exclude_post_types ) );
 	  }
     }
-    $post_types     = get_post_types( '', 'objects' );
+    $post_types = get_post_types( '', 'objects' );
 
 	if ( is_multisite() ) {
 	  $excluded_types = unserialize( get_site_option( 'make_paths_relative_exclude' ) );
@@ -311,7 +317,6 @@ final class Make_Paths_Relative_Admin {
       <form enctype="multipart/form-data" action="" method="POST" id="make-paths-relative-exclude-posts">
         <table class="form-table">
           <?php
-          $get_post_type = array();
           foreach ( $post_types as $post_type ) {
             if ( $post_type->name == 'revision'
               || $post_type->name == 'nav_menu_item' ) {
@@ -398,10 +403,19 @@ final class Make_Paths_Relative_Admin {
       __( '<a href="%s" title="Contact">Contact</a>', 'make-paths-relative' ),
       'https://www.yasglobal.com/#request-form'
     );
-    $settings_link = sprintf(
-      __( '<a href="%s" title="Settings">Settings</a>', 'make-paths-relative' ),
-		network_admin_url( 'admin.php?page=make-paths-relative-settings' )
-    );
+
+	if( is_multisite() ) {
+		$settings_link = sprintf(
+			__( '<a href="%s" title="Settings">Settings</a>', 'make-paths-relative' ),
+			network_admin_url( 'admin.php?page=make-paths-relative-settings' )
+		);
+	} else {
+		$settings_link = sprintf(
+			__( '<a href="%s" title="Settings">Settings</a>', 'make-paths-relative' ),
+			admin_url( 'admin.php?page=make-paths-relative-settings' )
+		);
+	}
+
     array_unshift( $links, $settings_link );
     array_unshift( $links, $contact );
     array_unshift( $links, $about );

--- a/frontend/class-make-paths-relative.php
+++ b/frontend/class-make-paths-relative.php
@@ -11,7 +11,7 @@ final class Make_Paths_Relative_Frontend {
    * Class constructor.
    */
   public function __construct() {
-    $make_relative_paths = unserialize( get_option( 'make_paths_relative' ) );
+    $make_relative_paths = unserialize( get_site_option( 'make_paths_relative' ) );
     if ( ! isset( $make_relative_paths ) || empty( $make_relative_paths ) ) {
       return;
     }
@@ -30,7 +30,7 @@ final class Make_Paths_Relative_Frontend {
     } elseif ( strpos( $host_name, '//' ) !== false ) {
       $host_name = str_replace( '//', '', $host_name );
     }
-    $this->make_paths_relative_url = $host_name;
+    $this->make_paths_relative_url = str_replace( '/wp', '', $host_name );
 
     $this->make_paths_relative_applied( $make_relative_paths );
   }
@@ -51,7 +51,7 @@ final class Make_Paths_Relative_Frontend {
     $current_post_type = get_post_type();
     if ( isset( $current_post_type ) && ! empty( $current_post_type ) ) {
       $get_exclude_post_types = unserialize(
-        get_option( 'make_paths_relative_exclude' )
+        get_site_option( 'make_paths_relative_exclude' )
       );
       if ( isset( $get_exclude_post_types['post_types'][$current_post_type] )
         && $get_exclude_post_types['post_types'][$current_post_type] == "on" ) {
@@ -93,7 +93,7 @@ final class Make_Paths_Relative_Frontend {
     $current_post_type = get_post_type();
     if ( isset( $current_post_type ) && ! empty( $current_post_type ) ) {
       $get_exclude_post_types = unserialize(
-        get_option( 'make_paths_relative_exclude' )
+        get_site_option( 'make_paths_relative_exclude' )
       );
       if ( isset( $get_exclude_post_types['post_types'][$current_post_type] )
         && $get_exclude_post_types['post_types'][$current_post_type] == "on" ) {
@@ -231,7 +231,7 @@ final class Make_Paths_Relative_Frontend {
     $current_post_type = get_post_type();
     if ( isset( $current_post_type ) && ! empty( $current_post_type ) ) {
       $get_exclude_post_types = unserialize(
-        get_option( 'make_paths_relative_exclude' )
+        get_site_option( 'make_paths_relative_exclude' )
       );
       if ( isset( $get_exclude_post_types['post_types'][$current_post_type] )
         && $get_exclude_post_types['post_types'][$current_post_type] == "on" ) {

--- a/frontend/class-make-paths-relative.php
+++ b/frontend/class-make-paths-relative.php
@@ -11,28 +11,36 @@ final class Make_Paths_Relative_Frontend {
    * Class constructor.
    */
   public function __construct() {
-    $make_relative_paths = unserialize( get_site_option( 'make_paths_relative' ) );
-    if ( ! isset( $make_relative_paths ) || empty( $make_relative_paths ) ) {
-      return;
-    }
+  	add_action( 'plugins_loaded', [ $this, 'on_loaded' ] );
+  }
 
-    $host_name = site_url();
-    if ( isset( $make_relative_paths['site_url'] )
-      && ! empty( $make_relative_paths['site_url'] ) ) {
-      $host_name = $make_relative_paths['site_url'];
-    }
-    $this->site_url = $host_name;
+  public function on_loaded() {
+	$opt = is_multisite() ? get_site_option( 'make_paths_relative' ) : get_option( 'make_paths_relative' );
 
-    if ( strpos( $host_name, 'http://' ) !== false ) {
-      $host_name = str_replace( 'http://', '', $host_name );
-    } elseif ( strpos( $host_name, 'https://' ) !== false ) {
-      $host_name = str_replace ( 'https://', '', $host_name );
-    } elseif ( strpos( $host_name, '//' ) !== false ) {
-      $host_name = str_replace( '//', '', $host_name );
-    }
-    $this->make_paths_relative_url = str_replace( '/wp', '', $host_name );
+	$make_relative_paths = unserialize( $opt );
+	if ( ! isset( $make_relative_paths ) || empty( $make_relative_paths ) ) {
+	  return;
+	}
 
-    $this->make_paths_relative_applied( $make_relative_paths );
+	$host_name = site_url();
+	if ( isset( $make_relative_paths['site_url'] )
+	  && ! empty( $make_relative_paths['site_url'] ) ) {
+	  $host_name = $make_relative_paths['site_url'];
+	}
+
+	$this->site_url = $host_name;
+
+	if ( strpos( $host_name, 'http://' ) !== false ) {
+	  $host_name = str_replace( 'http://', '', $host_name );
+	} elseif ( strpos( $host_name, 'https://' ) !== false ) {
+	  $host_name = str_replace ( 'https://', '', $host_name );
+	} elseif ( strpos( $host_name, '//' ) !== false ) {
+	  $host_name = str_replace( '//', '', $host_name );
+	}
+
+	$this->make_paths_relative_url = apply_filters( 'hack_relative_path', $host_name );
+
+	$this->make_paths_relative_applied( $make_relative_paths );
   }
 
   /**
@@ -48,29 +56,29 @@ final class Make_Paths_Relative_Frontend {
    *   Return the Relative Permalink
    */
   public function make_paths_relative_remove( $link ) {
-    $current_post_type = get_post_type();
-    if ( isset( $current_post_type ) && ! empty( $current_post_type ) ) {
-      $get_exclude_post_types = unserialize(
-        get_site_option( 'make_paths_relative_exclude' )
-      );
-      if ( isset( $get_exclude_post_types['post_types'][$current_post_type] )
-        && $get_exclude_post_types['post_types'][$current_post_type] == "on" ) {
-        return $link;
-      }
-    }
+	$current_post_type = get_post_type();
+	if ( isset( $current_post_type ) && ! empty( $current_post_type ) ) {
+	  $get_exclude_post_types = unserialize(
+	  	is_multisite() ? get_site_option( 'make_paths_relative_exclude' ) : get_option( 'make_paths_relative_exclude' )
+	  );
+	  if ( isset( $get_exclude_post_types['post_types'][$current_post_type] )
+		&& $get_exclude_post_types['post_types'][$current_post_type] == "on" ) {
+		return $link;
+	  }
+	}
 
-    $relative_link = $link;
-    $relative_link = str_replace(
-      'https://' . $this->make_paths_relative_url, '', $relative_link
-    );
-    $relative_link = str_replace(
-      'http://' . $this->make_paths_relative_url, '', $relative_link
-    );
-    $relative_link = str_replace(
-      '//' . $this->make_paths_relative_url, '', $relative_link
-    );
+	$relative_link = $link;
+	$relative_link = str_replace(
+	  'https://' . $this->make_paths_relative_url, '', $relative_link
+	);
+	$relative_link = str_replace(
+	  'http://' . $this->make_paths_relative_url, '', $relative_link
+	);
+	$relative_link = str_replace(
+	  '//' . $this->make_paths_relative_url, '', $relative_link
+	);
 
-    return apply_filters( 'paths_relative', $relative_link );
+	return apply_filters( 'paths_relative', $relative_link );
   }
 
   /**
@@ -90,38 +98,38 @@ final class Make_Paths_Relative_Frontend {
    *   Return the Relative Permalink
    */
   public function relative_post_urls( $link, $post, $leavename = false ) {
-    $current_post_type = get_post_type();
-    if ( isset( $current_post_type ) && ! empty( $current_post_type ) ) {
-      $get_exclude_post_types = unserialize(
-        get_site_option( 'make_paths_relative_exclude' )
-      );
-      if ( isset( $get_exclude_post_types['post_types'][$current_post_type] )
-        && $get_exclude_post_types['post_types'][$current_post_type] == "on" ) {
-        return $link;
-      }
-    }
+	$current_post_type = get_post_type();
+	if ( isset( $current_post_type ) && ! empty( $current_post_type ) ) {
+	  $get_exclude_post_types = unserialize(
+		  is_multisite() ? get_site_option( 'make_paths_relative_exclude' ) : get_option( 'make_paths_relative_exclude' )
+	  );
+	  if ( isset( $get_exclude_post_types['post_types'][$current_post_type] )
+		&& $get_exclude_post_types['post_types'][$current_post_type] == "on" ) {
+		return $link;
+	  }
+	}
 
-    if ( 'attachment' == $current_post_type && isset( $post->post_type )
-      && 'post' == $post->post_type ) {
-      $attachment = get_post( get_the_ID() );
-      if ( isset( $attachment->post_parent ) && 0 != $attachment->post_parent
-        && $post->ID === $attachment->post_parent ) {
-        return $link;
-      }
-    }
+	if ( 'attachment' == $current_post_type && isset( $post->post_type )
+	  && 'post' == $post->post_type ) {
+	  $attachment = get_post( get_the_ID() );
+	  if ( isset( $attachment->post_parent ) && 0 != $attachment->post_parent
+		&& $post->ID === $attachment->post_parent ) {
+		return $link;
+	  }
+	}
 
-    $relative_link = $link;
-    $relative_link = str_replace(
-      'https://' . $this->make_paths_relative_url, '', $relative_link
-    );
-    $relative_link = str_replace(
-      'http://' . $this->make_paths_relative_url, '', $relative_link
-    );
-    $relative_link = str_replace(
-      '//' . $this->make_paths_relative_url, '', $relative_link
-    );
+	$relative_link = $link;
+	$relative_link = str_replace(
+	  'https://' . $this->make_paths_relative_url, '', $relative_link
+	);
+	$relative_link = str_replace(
+	  'http://' . $this->make_paths_relative_url, '', $relative_link
+	);
+	$relative_link = str_replace(
+	  '//' . $this->make_paths_relative_url, '', $relative_link
+	);
 
-    return apply_filters( 'paths_relative', $relative_link );
+	return apply_filters( 'paths_relative', $relative_link );
   }
 
   /**
@@ -137,81 +145,81 @@ final class Make_Paths_Relative_Frontend {
    */
   private function make_paths_relative_applied( $make_relative_paths ) {
 
-    //Filters to make the permalinks to relative
-    if ( isset( $make_relative_paths['post_permalinks'] )
-      && ! empty( $make_relative_paths['post_permalinks'] ) ) {
-      add_filter( 'the_permalink',
-        array( $this, 'make_paths_relative_remove' ), 100
-      );
-      add_filter( 'post_link',
-        array( $this, 'relative_post_urls' ), 100, 3
-      );
-      add_filter( 'post_type_link',
-        array( $this, 'relative_post_urls' ), 100, 3
-      );
-      if ( defined( 'WPSEO_VERSION' ) ) {
-        add_filter( 'wpseo_xml_sitemap_post_url',
-          array( $this, 'sitemap_post_url' ), 100
-        );
-      }
-    }
+	//Filters to make the permalinks to relative
+	if ( isset( $make_relative_paths['post_permalinks'] )
+	  && ! empty( $make_relative_paths['post_permalinks'] ) ) {
+	  add_filter( 'the_permalink',
+		array( $this, 'make_paths_relative_remove' ), 100
+	  );
+	  add_filter( 'post_link',
+		array( $this, 'relative_post_urls' ), 100, 3
+	  );
+	  add_filter( 'post_type_link',
+		array( $this, 'relative_post_urls' ), 100, 3
+	  );
+	  if ( defined( 'WPSEO_VERSION' ) ) {
+		add_filter( 'wpseo_xml_sitemap_post_url',
+		  array( $this, 'sitemap_post_url' ), 100
+		);
+	  }
+	}
 
-    if ( isset( $make_relative_paths['page_permalinks'] )
-      && ! empty( $make_relative_paths['page_permalinks'] ) ) {
-      add_filter( 'page_link',
-        array( $this, 'make_paths_relative_remove' ), 100
-      );
-      add_filter( 'page_type_link',
-        array( $this, 'make_paths_relative_remove' ), 100, 2
-      );
-    }
+	if ( isset( $make_relative_paths['page_permalinks'] )
+	  && ! empty( $make_relative_paths['page_permalinks'] ) ) {
+	  add_filter( 'page_link',
+		array( $this, 'make_paths_relative_remove' ), 100
+	  );
+	  add_filter( 'page_type_link',
+		array( $this, 'make_paths_relative_remove' ), 100, 2
+	  );
+	}
 
-    if ( isset( $make_relative_paths['archive_permalinks'] )
-      && ! empty( $make_relative_paths['archive_permalinks'] ) ) {
-      add_filter( 'get_archives_link',
-        array( $this, 'make_paths_relative_remove' ), 100
-      );
-    }
+	if ( isset( $make_relative_paths['archive_permalinks'] )
+	  && ! empty( $make_relative_paths['archive_permalinks'] ) ) {
+	  add_filter( 'get_archives_link',
+		array( $this, 'make_paths_relative_remove' ), 100
+	  );
+	}
 
-    if ( isset( $make_relative_paths['author_permalinks'] )
-      && ! empty( $make_relative_paths['author_permalinks'] ) ) {
-      add_filter( 'author_link',
-        array( $this, 'make_paths_relative_remove' ), 100
-      );
-    }
+	if ( isset( $make_relative_paths['author_permalinks'] )
+	  && ! empty( $make_relative_paths['author_permalinks'] ) ) {
+	  add_filter( 'author_link',
+		array( $this, 'make_paths_relative_remove' ), 100
+	  );
+	}
 
-    if ( isset( $make_relative_paths['category_permalinks'] )
-      && ! empty( $make_relative_paths['category_permalinks'] ) ) {
-      add_filter( 'term_link',
-        array( $this, 'make_paths_relative_remove' ), 100, 3
-      );
-    }
+	if ( isset( $make_relative_paths['category_permalinks'] )
+	  && ! empty( $make_relative_paths['category_permalinks'] ) ) {
+	  add_filter( 'term_link',
+		array( $this, 'make_paths_relative_remove' ), 100, 3
+	  );
+	}
 
-    //Filters to make the scripts and style urls to relative
-    if ( isset( $make_relative_paths['scripts_src'] )
-      && ! empty( $make_relative_paths['scripts_src'] ) ) {
-      add_filter( 'script_loader_src',
-        array( $this, 'make_paths_relative_remove' ), 100
-      );
-    }
+	//Filters to make the scripts and style urls to relative
+	if ( isset( $make_relative_paths['scripts_src'] )
+	  && ! empty( $make_relative_paths['scripts_src'] ) ) {
+	  add_filter( 'script_loader_src',
+		array( $this, 'make_paths_relative_remove' ), 100
+	  );
+	}
 
-    if ( isset( $make_relative_paths['styles_src'] )
-      && ! empty( $make_relative_paths['styles_src'] ) ) {
-      add_filter( 'style_loader_src',
-        array( $this, 'make_paths_relative_remove' ), 100
-      );
-    }
+	if ( isset( $make_relative_paths['styles_src'] )
+	  && ! empty( $make_relative_paths['styles_src'] ) ) {
+	  add_filter( 'style_loader_src',
+		array( $this, 'make_paths_relative_remove' ), 100
+	  );
+	}
 
-    //Filter to make the media(image) src to relative
-    if ( isset( $make_relative_paths['image_paths'] )
-      && ! empty( $make_relative_paths['image_paths'] ) ) {
-      add_filter( 'wp_get_attachment_url',
-        array( $this, 'make_paths_relative_remove' ), 100
-      );
-      add_filter( 'wp_calculate_image_srcset',
-        array( $this, 'make_paths_relative_remove_srcset' ), 100
-      );
-    }
+	//Filter to make the media(image) src to relative
+	if ( isset( $make_relative_paths['image_paths'] )
+	  && ! empty( $make_relative_paths['image_paths'] ) ) {
+	  add_filter( 'wp_get_attachment_url',
+		array( $this, 'make_paths_relative_remove' ), 100
+	  );
+	  add_filter( 'wp_calculate_image_srcset',
+		array( $this, 'make_paths_relative_remove_srcset' ), 100
+	  );
+	}
   }
 
   /**
@@ -228,35 +236,35 @@ final class Make_Paths_Relative_Frontend {
    */
   public function make_paths_relative_remove_srcset( $image_srcset ) {
 
-    $current_post_type = get_post_type();
-    if ( isset( $current_post_type ) && ! empty( $current_post_type ) ) {
-      $get_exclude_post_types = unserialize(
-        get_site_option( 'make_paths_relative_exclude' )
-      );
-      if ( isset( $get_exclude_post_types['post_types'][$current_post_type] )
-        && $get_exclude_post_types['post_types'][$current_post_type] == "on" ) {
-        return $image_srcset;
-      }
-    }
+	$current_post_type = get_post_type();
+	if ( isset( $current_post_type ) && ! empty( $current_post_type ) ) {
+	  $get_exclude_post_types = unserialize(
+		is_multisite() ? get_site_option( 'make_paths_relative_exclude' ) : get_option( 'make_paths_relative_exclude' )
+	  );
+	  if ( isset( $get_exclude_post_types['post_types'][$current_post_type] )
+		&& $get_exclude_post_types['post_types'][$current_post_type] == "on" ) {
+		return $image_srcset;
+	  }
+	}
 
-    if ( apply_filters( 'srcset_paths_relative', '__true' ) ) {
-      foreach ( $image_srcset as $key => $value ) {
-        if ( isset( $value['url'] ) ) {
-          $value['url'] = str_replace(
-            'https://' . $this->make_paths_relative_url, '', $value['url']
-          );
-          $value['url'] = str_replace(
-            'http://' . $this->make_paths_relative_url, '', $value['url']
-          );
-          $value['url'] = str_replace(
-            '//' . $this->make_paths_relative_url, '', $value['url']
-          );
-          $image_srcset[$key]['url'] = $value['url'];
-        }
-      }
-    }
+	if ( apply_filters( 'srcset_paths_relative', '__true' ) ) {
+	  foreach ( $image_srcset as $key => $value ) {
+		if ( isset( $value['url'] ) ) {
+		  $value['url'] = str_replace(
+			'https://' . $this->make_paths_relative_url, '', $value['url']
+		  );
+		  $value['url'] = str_replace(
+			'http://' . $this->make_paths_relative_url, '', $value['url']
+		  );
+		  $value['url'] = str_replace(
+			'//' . $this->make_paths_relative_url, '', $value['url']
+		  );
+		  $image_srcset[$key]['url'] = $value['url'];
+		}
+	  }
+	}
 
-    return $image_srcset;
+	return $image_srcset;
   }
 
   /**
@@ -272,10 +280,10 @@ final class Make_Paths_Relative_Frontend {
    *   Return Absolute Permalink
    */
   public function sitemap_post_url( $post_permalink ) {
-    if ( strpos( $post_permalink, $this->site_url ) === false
-      && isset( $post_permalink[0] ) && $post_permalink[0] == '/' ) {
-      return $this->site_url . $post_permalink;
-    }
-    return $post_permalink;
+	if ( strpos( $post_permalink, $this->site_url ) === false
+	  && isset( $post_permalink[0] ) && $post_permalink[0] == '/' ) {
+	  return $this->site_url . $post_permalink;
+	}
+	return $post_permalink;
   }
 }

--- a/make-paths-relative.php
+++ b/make-paths-relative.php
@@ -132,7 +132,11 @@ final class Make_Paths_Relative {
         'styles_src'           =>  'on',
         'image_paths'          =>  'on'
       );
-      update_site_option( 'make_paths_relative', serialize( $default_activate ) );
+		if( is_multisite() ) {
+			update_site_option( 'make_paths_relative', serialize( $default_activate ) );
+		} else {
+			update_option( 'make_paths_relative', serialize( $default_activate ) );
+		}
     }
   }
 
@@ -145,8 +149,13 @@ final class Make_Paths_Relative {
    * @return void
    */
   public static function plugin_uninstall() {
-    delete_site_option( 'make_paths_relative' );
-    delete_site_option( 'make_paths_relative_exclude' );
+    if( is_multisite() ) {
+  		delete_site_option( 'make_paths_relative' );
+    	delete_site_option( 'make_paths_relative_exclude' );
+	} else {
+		delete_option( 'make_paths_relative' );
+		delete_option( 'make_paths_relative_exclude' );
+	}
   }
 
   /**

--- a/make-paths-relative.php
+++ b/make-paths-relative.php
@@ -132,7 +132,7 @@ final class Make_Paths_Relative {
         'styles_src'           =>  'on',
         'image_paths'          =>  'on'
       );
-      update_option( 'make_paths_relative', serialize( $default_activate ) );
+      update_site_option( 'make_paths_relative', serialize( $default_activate ) );
     }
   }
 
@@ -145,8 +145,8 @@ final class Make_Paths_Relative {
    * @return void
    */
   public static function plugin_uninstall() {
-    delete_option( 'make_paths_relative' );
-    delete_option( 'make_paths_relative_exclude' );
+    delete_site_option( 'make_paths_relative' );
+    delete_site_option( 'make_paths_relative_exclude' );
   }
 
   /**


### PR DESCRIPTION
Featured changes to make the plugin multisite compatible.
Added conditionals for network wide site options and functions if multisite active and plugin network wide activated.
Added a filter so users can hack the default site_url(). _This is useful for example on the roots.io stack (trellis + bedrock)._